### PR TITLE
fix(security): remove hardcoded JWT signing key and database password

### DIFF
--- a/server/configs/config.yaml
+++ b/server/configs/config.yaml
@@ -1,6 +1,6 @@
 # jwt configuration
 jwt:
-  signing-key: pddzl
+  signing-key: ""  # REQUIRED: Set via JWT_SIGNING_KEY env var
   expires-time: 86400
   buffer-time: 43200
   issuer: pddzl
@@ -49,7 +49,7 @@ pgsql:
   config: 'sslmode=disable TimeZone=Asia/Shanghai'
   db-name: 'td27'
   username: 'postgres'
-  password: 'td27admin'
+  password: ""  # REQUIRED: Set via DB_PASSWORD env var
   max-idle-conns: 10
   max-open-conns: 100
   log-mode: false

--- a/server/internal/core/viper.go
+++ b/server/internal/core/viper.go
@@ -80,6 +80,9 @@ func validateConfig(cfg *configs.Server) error {
 	if cfg.Pgsql.Username == "" {
 		return fmt.Errorf("PgSQL username is required")
 	}
+	if cfg.Pgsql.Password == "" {
+		return fmt.Errorf("PgSQL password is required")
+	}
 
 	// 验证系统配置
 	if cfg.System.Port <= 0 {


### PR DESCRIPTION
## Summary

This PR removes hardcoded credentials from the default configuration file.

### CWE-798: Use of Hard-coded Credentials

The default `configs/config.yaml` contained:
- **JWT signing key**: `pddzl` — anyone who knows this key can forge valid JWTs and impersonate any user including administrators
- **Database password**: `td27admin` — exposed PostgreSQL credentials

### Changes

1. **`configs/config.yaml`**: Set `signing-key` and `password` to empty strings with comments directing users to set their own values
2. **`internal/core/viper.go`**: Added validation for empty database password (the existing validation already rejects empty JWT signing keys with a clear error message)

### Impact

An attacker with knowledge of these default credentials could:
- Forge JWT tokens to gain unauthorized access to any user account including admin
- Connect directly to the PostgreSQL database